### PR TITLE
Timeout for avd start

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath "com.github.trevjonez:AVD-Gradle-Plugin:0.2.1"
+        classpath "com.github.trevjonez:AVD-Gradle-Plugin:0.3.0"
     }
+}
 ```
 
 2. Apply the plugin
@@ -79,6 +80,7 @@ AVD {
             }
             launchOption("-wipe-data")
             launchOption("-memory", "2048") //varargs
+            timeout 120 //default null (optional) in seconds
         }
     }
 }
@@ -100,7 +102,7 @@ AVD {
  
  AVD plugin version | Gradle version | Android plugin version
  ----- | ---- | -----
- 0.2.1 | 4.3.1  | 3.0.0
+ 0.3.0 | 4.3.1  | 3.0.0
  
  
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -41,4 +41,4 @@ task clean(type: Delete) {
 
 
 group = 'com.github.trevjonez'
-version = '0.2.1'
+version = '0.3.0'

--- a/plugin/src/main/kotlin/com/trevjonez/avdgp/dsl/NamedConfigurationGroup.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/avdgp/dsl/NamedConfigurationGroup.kt
@@ -33,6 +33,11 @@ open class NamedConfigurationGroup(val name: String) {
         values.forEach { launchOptions.add(it) }
     }
 
+    var timeout: Long? = null
+    fun timeout(value: Long?) {
+        timeout = value
+    }
+
     fun systemImageKey(): String {
         return "system-images;${avdConfig.api.cliValue};${avdConfig.type.cliValue};${avdConfig.abi}"
     }

--- a/plugin/src/main/kotlin/com/trevjonez/avdgp/rx/SocketRxConverters.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/avdgp/rx/SocketRxConverters.kt
@@ -31,16 +31,16 @@ fun Socket.toObservable(input: Observable<String>): Observable<String> {
             emitter.setDisposable(disposable)
 
             val out = getOutputStream().bufferedWriter()
-            input.observeOn(Schedulers.io()).subscribe {
+            input.observeOn(Schedulers.io()).subscribe({
                 out.write(it)
                 out.newLine()
                 out.flush()
-            } addTo disposable
+            }, emitter::onError) addTo disposable
 
             buffer(source(getInputStream()))
                     .readLines()
                     .subscribeOn(Schedulers.io())
-                    .subscribe { emitter.onNext(it) } addTo disposable
+                    .subscribe(emitter::onNext) addTo disposable
 
             object : Disposable {
                 override fun isDisposed(): Boolean {

--- a/plugin/src/test/kotlin/com/trevjonez/avdgp/PluginTest.kt
+++ b/plugin/src/test/kotlin/com/trevjonez/avdgp/PluginTest.kt
@@ -720,6 +720,7 @@ class PluginTest {
                                     type "google_apis"
                                     deviceId "Nexus 5X"
                                 }
+                                timeout 60
                             }
                         }
                         acceptAndroidSdkLicense true


### PR DESCRIPTION
This also makes the stop task wait until the avd is gone before completing. should help with race conditions in pipeline style scripts.

some extra logging and hopefully a fix for the timezone warning in here as well by adding a timeout to the stdout stream of the query property observable.